### PR TITLE
fix: Remove definition of vue-jest as peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
   "main": "./lib/index.js",
   "peerDependencies": {
     "vue": "^2.5",
-    "vue-jest": "^4.0.0-beta.3",
     "vue-template-compiler": "^2.5"
   },
   "repository": {


### PR DESCRIPTION
Partially closes #38 

Right now, vue-jest offers two packages to work with Vue 2:

* `vue-jest@4`, that supports Jest 26.
* `@vue/vue2-jest@27`, that supports Jest 27.

Since these are different packages, I'm not sure there's a smart way to define the proper peerDep definition (it would be great if it could depend on the installed Jest version).

With npm 7, having the wrong peerDeps means the installation phase will fail.

Thus, I believe not defining any `peerDeps` is the simplest fix for this problem.

---

Another solution is to mark these packages and optional peerDeps, but I'm not sure this is any better:

```json
"peerDependencies": { 
  "vue-jest": "^4"
},
"peerDependenciesMeta": {
  "vue-jest": {
    "optional": true
  }
}
```